### PR TITLE
Fix for undefined method `name' error

### DIFF
--- a/lib/slowhandcuke/formatter.rb
+++ b/lib/slowhandcuke/formatter.rb
@@ -2,7 +2,7 @@ require 'cucumber/formatter/pretty'
 module Slowhandcuke
   class Formatter < Cucumber::Formatter::Pretty
     def before_step( step )
-      @io.printf "... #{step.name}"
+      @io.printf "... #{step}"
       @io.flush
     end
 


### PR DESCRIPTION
```
  undefined method `name' for #<Cucumber::Formatter::LegacyApi::Ast::StepInvocation:0x00563ba71b6960> (NoMethodError)
```